### PR TITLE
fix: typo in into.md

### DIFF
--- a/src/intro.md
+++ b/src/intro.md
@@ -1,3 +1,3 @@
 # RustPython Docs
 
-### Feel free to browse the table of contents on the right
+### Feel free to browse the table of contents on the left


### PR DESCRIPTION
Hi!

It seems like the table of contents is on the left, not on the right ;-)

Edit: do you think you can add the `hacktoberfest` tag to this repository?